### PR TITLE
Fixes incorrect computation of ERR

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,7 +23,6 @@ jobs:
           - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-tests.yaml
+++ b/.github/workflows/R-CMD-tests.yaml
@@ -20,10 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,  r: 'release'}
-          - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,8 +3,6 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
 
 name: test-coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: zcurve
 Title: An Implementation of Z-Curves
-Version: 2.4.4
+Version: 2.4.5
 Authors@R: c(
     person("František", "Bartoš", email = "f.bartos96@gmail.com", role = c("aut", "cre")),
     person("Ulrich", "Schimmack", email = "ulrich.schimmack@utoronto.ca", role = c("aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## version 2.4.5
+- Fixes incorrect computation of ERR identified by Richard D. Morey 
+
 ## version 2.4.4
 - Fixes incorrect computation of EDR/ERR when the start of the fitting range does not match the significance level.
 

--- a/R/tools.R
+++ b/R/tools.R
@@ -76,7 +76,9 @@ power_to_z  <- function(power, alpha = .05, a = stats::qnorm(alpha/2,lower.tail 
   # 1/sum(weights / power) # old formula based on estimated weights
 }
 .get_ERR    <- function(power2, power1, pop_weights){
-  sum(pop_weights * power2 * power1) / sum(pop_weights * power2)
+  # power_n is probability passing opposite criterion
+  power_n <- power2 - power1
+  sum(pop_weights * (power_n^2 + power1^2)) / sum(pop_weights * power2)
   # sum(weights * power)  # old formula based on estimated weights
 }
 

--- a/tests/testthat/test-zcurve.R
+++ b/tests/testthat/test-zcurve.R
@@ -17,7 +17,7 @@ test_that("z-curve EM can be fitted and reproduces OSC results", {
       ""                    , 
       "Estimates:"          , 
       "      ERR       EDR ",
-      "0.6180663 0.3905984 "    
+      "0.6180361 0.3905984 "    
     ))
   
   # basic summary
@@ -81,7 +81,7 @@ test_that("z-curve KD2 can be fitted and reproduces OSC results", {
       ""                                                       ,
       "Estimates:"                                             ,
       "      ERR       EDR "                                   ,
-      "0.6133975 0.5064694 "    
+      "0.6132671 0.5064694 "    
     ))
   
   # basic summary
@@ -93,7 +93,7 @@ test_that("z-curve KD2 can be fitted and reproduces OSC results", {
       "model: KD2 via density"                                                                  ,
       ""                                                                                        ,
       "    Estimate  l.CI  u.CI"                                                                ,
-      "ERR    0.613 0.496 0.745"                                                                ,
+      "ERR    0.613 0.495 0.745"                                                                ,
       "EDR    0.506 0.141 0.714"                                                                ,
       ""                                                                                        ,
       "Model converged in 46 iterations"                                                        ,


### PR DESCRIPTION
This pull request changes the function `.get_ERR()` so that it correctly uses the sum of the squared probablities of passing the "far" and "near" significance criteria in the the two-sided case, as discussed with @FBartos.